### PR TITLE
Internal linkage for _obf_date_hash() to prevent date/time macro issues with string obfuscation

### DIFF
--- a/Obfusk8/Instrumentation/materialization/transform/AES8.hpp
+++ b/Obfusk8/Instrumentation/materialization/transform/AES8.hpp
@@ -6,7 +6,7 @@ using namespace std;
 
 NOOPT
 
-constexpr uint32_t _obf_date_hash() {
+static constexpr uint32_t _obf_date_hash() {
     const char* s = __DATE__;
     uint32_t h = 0x811C9DC5;
     while (*s) { h = (h ^ (uint8_t)*s) * 0x01000193; ++s; }


### PR DESCRIPTION
Currently, `_obf_date_hash()` is only declared as `constexpr` which makes it implicitly `inline` and therefore only one instance is created per-compilation. This causes significant issues with string obfuscation.

When compiling in parallel, or when compiling single objects instead of the entire project, the `__DATE__` and `__TIME__` expansions in the single instance of `_obf_date_hash()` may not match the one used to create the key for a newly-compiled obfuscated string, breaking the decryption.

Example:

```cpp
// a.cpp
#include "AES8.hpp"
const wchar_t* get_a() {
    static auto s = OBFUSCATE_WSTRING(L"hello from A");
    return s.c_str(); // may decrypt correctly or garbage depending on link order
}

// b.cpp
#include "AES8.hpp"
const wchar_t* get_b() {
    static auto s = OBFUSCATE_WSTRING(L"hello from B");
    return s.c_str(); // same — one of these will be wrong
}
```

Depending on which file gets compiled first, only one those strings may decrypt correctly because it's using its own hash function, while the other fails.

# Fix

Add `static` to the declaration of `constexpr uint32_t _obf_date_hash()` -> `static constexpr uint32_t _obf_date_hash()`

This way, each compilation unit will get its own, correct definition of the function with the same __TIME__ and __DATE__ used to create the encryption key.